### PR TITLE
Add support for array-based fields and arbitrary operators

### DIFF
--- a/conditionize.jquery.js
+++ b/conditionize.jquery.js
@@ -18,7 +18,7 @@
     } 
 
     return this.each( function() {
-      var listenTo = "[name=" + $(this).data('cond-option') + "]";
+      var listenTo = "[name=" + $(this).data('cond-option').replace( /(:|\.|\[|\]|,)/g, "\\$1" ) + "]";
       var listenFor = $(this).data('cond-value');
       var $section = $(this);
   

--- a/conditionize.jquery.js
+++ b/conditionize.jquery.js
@@ -9,7 +9,7 @@
       if ($(listenTo).is('select, input[type=text]') && $(listenTo).val() == listenFor ) {
         $section.slideDown();
       }
-      else if ($(listenTo + ":checked").val() == listenFor) {
+      else if ($(listenTo + ":checked").filter(function(idx, elem){return elem.value == listenFor);}).length > 0) {
         $section.slideDown();
       }
       else {

--- a/conditionize.jquery.js
+++ b/conditionize.jquery.js
@@ -1,37 +1,56 @@
 (function($) {
-  $.fn.conditionize = function(options){ 
-    
-     var settings = $.extend({
+  $.fn.conditionize = function(options) {
+
+    var settings = $.extend({
         hideJS: true
     }, options );
-    
-    $.fn.showOrHide = function(listenTo, listenFor, $section) {
-      if ($(listenTo).is('select, input[type=text]') && $(listenTo).val() == listenFor ) {
+
+    $.fn.eval = function(valueIs, valueShould, operator) {
+      switch(operator) {
+        case '==':
+            return valueIs == valueShould;
+            break;
+        case '!=':
+            return valueIs != valueShould;
+        case '<=':
+            return valueIs <= valueShould;
+        case '<':
+            return valueIs < valueShould;
+        case '>=':
+            return valueIs >= valueShould;
+        case '>':
+            return valueIs > valueShould;
+      }
+    }
+
+    $.fn.showOrHide = function(listenTo, listenFor, operator, $section) {
+      if ($(listenTo).is('select, input[type=text]') && $.fn.eval($(listenTo).val(), listenFor, operator)) {
         $section.slideDown();
       }
-      else if ($(listenTo + ":checked").filter(function(idx, elem){return elem.value == listenFor);}).length > 0) {
+      else if ($(listenTo + ":checked").filter(function(idx, elem){return $.fn.eval(elem.value, listenFor, operator);}).length > 0) {
         $section.slideDown();
       }
       else {
         $section.slideUp();
       }
-    } 
+    }
 
     return this.each( function() {
       var listenTo = "[name=" + $(this).data('cond-option').replace( /(:|\.|\[|\]|,)/g, "\\$1" ) + "]";
       var listenFor = $(this).data('cond-value');
+      var operator = $(this).data('cond-operator') ? $(this).data('cond-operator') : '==';
       var $section = $(this);
-  
+
       //Set up event listener
       $(listenTo).on('change', function() {
-        $.fn.showOrHide(listenTo, listenFor, $section);
+        $.fn.showOrHide(listenTo, listenFor, operator, $section);
       });
       //If setting was chosen, hide everything first...
       if (settings.hideJS) {
         $(this).hide();
       }
       //Show based on current value on page load
-      $.fn.showOrHide(listenTo, listenFor, $section);
+      $.fn.showOrHide(listenTo, listenFor, operator, $section);
     });
   }
 }(jQuery));


### PR DESCRIPTION
This set consists of the following three changes:

- Escape cond-option values
    This change allows a cond-option data attribute to contain the following
    unescaped characters :.[],

- Correctly handle array-based values
    A common use-case is having multiple checkboxes with the same name
    suffixed with the 'array' characters '[]'. In this case, the selector
    produces multiple checkboxes.

    This change ensures that we only look at the elements which actually
    match the expected value.
- Allow for arbitrary comparison operators
    At present conditionize can only conditionally show elements when a
    value is exactly equal to a specific control value.

    This change allows for the conditions to be based on all other
    comparison operators. Specifying the 'data-cond-operator' attribute as
    one of '==', '!=', '<=', '<', '>=', '>' tells conditionize the operator
    which should be used to make the comparison. When cond-operator is not
    specified, we fall back to '=='.